### PR TITLE
security: Add .env files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@ __pycache__/
 build/
 dist/
 
+# Environment variables (SECURITY: Never commit secrets!)
+.env
+.env.local
+.env.*.local
+.env.production
+.env.development
+.env.test
+
 # macOS
 .DS_Store
 


### PR DESCRIPTION
## Summary
Critical security fix to prevent accidental commit of environment files containing secrets.

## Changes
- Added  and variants to 
- Protects API keys, database credentials, and other secrets from being committed to Git
- Prevents common security breach vector (leaked secrets in Git history)

## Type
- [x] Security fix
- [x] Chore

## Risk & Impact
- [x] No PHI/PII in logs or screenshots
- [x] Security improvement - prevents secret leakage
- [x] No breaking changes
- [x] Backward-compatible

## Protected Files
- `.env` - Main environment file
- `.env.local` - Local overrides
- `.env.*.local` - Environment-specific local files
- `.env.production` - Production secrets
- `.env.development` - Development secrets
- `.env.test` - Test environment secrets

## Checklist
- [x] Security best practice implemented
- [x] Common vulnerability prevented
- [x] No functionality changes
- [x] Critical for production deployment